### PR TITLE
analyzer_bin_envvar used to get analyzer binary in runtime

### DIFF
--- a/doc/csgcca.adoc
+++ b/doc/csgcca.adoc
@@ -88,6 +88,10 @@ ENVIRONMENT VARIABLES
     are appended even if they already appear in the command line and they are
     always appended at the end of the command line.
 
+*CSGCCA_ANALYZER_BIN*::
+    If set to a non-empty string, csgcca will use the value as a path (relative
+    or absolute) to analyzer binary.
+
 
 BUGS
 ----

--- a/src/csclng.c
+++ b/src/csclng.c
@@ -37,6 +37,8 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSCLNG";
 
 const char *analyzer_name = "clang";
 
+const char *analyzer_bin_envvar = NULL;
+
 const bool analyzer_is_cxx_ready = true;
 
 const bool analyzer_is_gcc_compatible = true;

--- a/src/csclng.c
+++ b/src/csclng.c
@@ -37,7 +37,7 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSCLNG";
 
 const char *analyzer_name = "clang";
 
-const char *analyzer_bin_envvar = NULL;
+const char *analyzer_bin_envvar_name = NULL;
 
 const bool analyzer_is_cxx_ready = true;
 

--- a/src/cscppc.c
+++ b/src/cscppc.c
@@ -38,7 +38,7 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSCPPC";
 
 const char *analyzer_name = "cppcheck";
 
-const char *analyzer_bin_envvar = NULL;
+const char *analyzer_bin_envvar_name = NULL;
 
 const bool analyzer_is_cxx_ready = true;
 

--- a/src/cscppc.c
+++ b/src/cscppc.c
@@ -38,6 +38,8 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSCPPC";
 
 const char *analyzer_name = "cppcheck";
 
+const char *analyzer_bin_envvar = NULL;
+
 const bool analyzer_is_cxx_ready = true;
 
 const bool analyzer_is_gcc_compatible = false;

--- a/src/csgcca.c
+++ b/src/csgcca.c
@@ -37,7 +37,7 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSGCCA";
 
 const char *analyzer_name = "gcc";
 
-const char *analyzer_bin_envvar = "CSGCCA_ANALYZER_BIN";
+const char *analyzer_bin_envvar_name = "CSGCCA_ANALYZER_BIN";
 
 const bool analyzer_is_cxx_ready = false;
 

--- a/src/csgcca.c
+++ b/src/csgcca.c
@@ -37,6 +37,8 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSGCCA";
 
 const char *analyzer_name = "gcc";
 
+const char *analyzer_bin_envvar = "CSGCCA_ANALYZER_BIN";
+
 const bool analyzer_is_cxx_ready = false;
 
 const bool analyzer_is_gcc_compatible = true;

--- a/src/csmatch.c
+++ b/src/csmatch.c
@@ -37,7 +37,7 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSMATCH";
 
 const char *analyzer_name = "smatch";
 
-const char *analyzer_bin_envvar = NULL;
+const char *analyzer_bin_envvar_name = NULL;
 
 const bool analyzer_is_cxx_ready = false;
 

--- a/src/csmatch.c
+++ b/src/csmatch.c
@@ -37,6 +37,8 @@ const char *wrapper_debug_envvar_name = "DEBUG_CSMATCH";
 
 const char *analyzer_name = "smatch";
 
+const char *analyzer_bin_envvar = NULL;
+
 const bool analyzer_is_cxx_ready = false;
 
 const bool analyzer_is_gcc_compatible = true;

--- a/src/cswrap-core.c
+++ b/src/cswrap-core.c
@@ -393,8 +393,14 @@ static void consider_running_analyzer(
         return;
     }
 
+    const char *analyzer = NULL;
+    if (analyzer_bin_envvar)
+        analyzer = getenv(analyzer_bin_envvar);
+    if (!analyzer || !analyzer[0])
+        analyzer = analyzer_name;
+
     /* make sure that the analyzer process is named analyzer_name */
-    argv[0] = (char *) analyzer_name;
+    argv[0] = (char *) analyzer;
 
     /* make sure there is NULL at the end of argv[] */
     argv[argc_total - 1] = NULL;
@@ -410,7 +416,7 @@ static void consider_running_analyzer(
     }
 
     /* try to start analyzer */
-    pid_analyzer = launch_tool(analyzer_name, argv, /* del_args */ NULL);
+    pid_analyzer = launch_tool(analyzer, argv, /* del_args */ NULL);
 
     /* FIXME: release also the memory allocated by asprintf() and
        read_custom_opts() */

--- a/src/cswrap-core.c
+++ b/src/cswrap-core.c
@@ -393,14 +393,14 @@ static void consider_running_analyzer(
         return;
     }
 
-    const char *analyzer = NULL;
-    if (analyzer_bin_envvar)
-        analyzer = getenv(analyzer_bin_envvar);
-    if (!analyzer || !analyzer[0])
-        analyzer = analyzer_name;
+    const char *analyzer_name_actual = NULL;
+    if (analyzer_bin_envvar_name)
+        analyzer_name_actual = getenv(analyzer_bin_envvar_name);
+    if (!analyzer_name_actual || !analyzer_name_actual[0])
+        analyzer_name_actual = analyzer_name;
 
-    /* make sure that the analyzer process is named analyzer_name */
-    argv[0] = (char *) analyzer;
+    /* make sure that the analyzer process is named analyzer_name_actual */
+    argv[0] = (char *) analyzer_name_actual;
 
     /* make sure there is NULL at the end of argv[] */
     argv[argc_total - 1] = NULL;
@@ -416,7 +416,7 @@ static void consider_running_analyzer(
     }
 
     /* try to start analyzer */
-    pid_analyzer = launch_tool(analyzer, argv, /* del_args */ NULL);
+    pid_analyzer = launch_tool(analyzer_name_actual, argv, /* del_args */ NULL);
 
     /* FIXME: release also the memory allocated by asprintf() and
        read_custom_opts() */

--- a/src/cswrap-core.h
+++ b/src/cswrap-core.h
@@ -35,19 +35,11 @@ extern const char *wrapper_debug_envvar_name;
 extern const char *analyzer_name;
 
 /**
- * Environment variable name which is used
- * to determine how to start analyzer.
- * The value can be NULL.
- * If value is NULL or specified environment
- * variable is not set or it has empty string
- * as it's value, the string provided in
- * analyzer_name will be used to run analyzer
- *
- * Note: this environment variable value
- * doesn't need to provide parameters to
- * run analyzer, just the binary it self.
+ * The name of the environment variable which value is the path (relative or
+ * absolute) to the analyzer binary. If value of the environment variable is
+ * non-empty string it's used to override the value if analyzer_name.
  */
-extern const char *analyzer_bin_envvar;
+extern const char *analyzer_bin_envvar_name;
 
 extern const bool analyzer_is_cxx_ready;
 

--- a/src/cswrap-core.h
+++ b/src/cswrap-core.h
@@ -34,6 +34,21 @@ extern const char *wrapper_debug_envvar_name;
 
 extern const char *analyzer_name;
 
+/**
+ * Environment variable name which is used
+ * to determine how to start analyzer.
+ * The value can be NULL.
+ * If value is NULL or specified environment
+ * variable is not set or it has empty string
+ * as it's value, the string provided in
+ * analyzer_name will be used to run analyzer
+ *
+ * Note: this environment variable value
+ * doesn't need to provide parameters to
+ * run analyzer, just the binary it self.
+ */
+extern const char *analyzer_bin_envvar;
+
 extern const bool analyzer_is_cxx_ready;
 
 extern const bool analyzer_is_gcc_compatible;


### PR DESCRIPTION
Modules can define analyzer_bin_envvar field as non-NULL. If it's done, an environment variable with the same name as the value of the field will be used to determine the path to the analyzer binary.