### PR TITLE
doc: minor improvements in man pages

### DIFF
--- a/doc/csclng.adoc
+++ b/doc/csclng.adoc
@@ -14,11 +14,11 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-csclng is a compiler wrapper that runs clang in background.  Create a
+csclng is a compiler wrapper that runs Clang in background.  Create a
 symbolic link to csclng named as your compiler (gcc, g++, ...) and put it
 to your $PATH.
 
-The following parameters are given to clang by default:
+The following parameters are given to Clang by default:
 
     * --analyze
 
@@ -26,7 +26,7 @@ The following parameters are given to clang by default:
 
     * -fno-caret-diagnostics
 
-The following parameters are passed to clang from compiler's command line:
+The following parameters are passed to Clang from compiler's command line:
 
     * -D...
 
@@ -66,7 +66,7 @@ The following file extensions are recognized as C/C++ source files:
 
 If csclng is installed on system, the following command activates the wrapper:
 -------------------------------------------------
-export PATH="`csclng --print-path-to-wrap`:$PATH"
+export PATH="$(csclng --print-path-to-wrap):$PATH"
 -------------------------------------------------
 
 
@@ -82,7 +82,7 @@ OPTIONS
 EXIT STATUS
 -----------
 csclng propagates the exit status returned by the compiler (in case csclng
-succeeds to run the compiler).  The exit status returned by clang does not
+succeeds to run the compiler).  The exit status returned by Clang does not
 affect the resulting exit status.
 
 
@@ -90,7 +90,7 @@ ENVIRONMENT VARIABLES
 ---------------------
 *DEBUG_CSCLNG*::
     If set to a non-empty string, csclng outputs the list of parameters given
-    to clang to the standard output.
+    to Clang to the standard output.
 
 *CSCLNG_ADD_OPTS*::
     csclng expects a colon-separated list of Clang options that should be
@@ -101,7 +101,7 @@ ENVIRONMENT VARIABLES
 
 BUGS
 ----
-Please report bugs and feature requests at https://github.com/csutils/cscppc .
+Please report bugs and feature requests at https://github.com/csutils/cscppc.
 
 
 AUTHOR

--- a/doc/cscppc.adoc
+++ b/doc/cscppc.adoc
@@ -18,7 +18,7 @@ cscppc is a compiler wrapper that runs cppcheck in background.  Create a
 symbolic link to cscppc named as your compiler (gcc, g++, ...) and put it
 to your $PATH.
 
-The following parameters are given to cppcheck by default:
+The following parameters are given to Cppcheck by default:
 
     * -D\__GNUC__
 
@@ -42,7 +42,7 @@ The following parameters are given to cppcheck by default:
 
     * --suppressions-list=/usr/share/cscppc/default.supp
 
-The following parameters are passed to cppcheck from compiler's command line:
+The following parameters are passed to Cppcheck from compiler's command line:
 
     * -D...
 
@@ -62,7 +62,7 @@ The following file extensions are recognized as C/C++ source files:
 
 If cscppc is installed on system, the following command activates the wrapper:
 -------------------------------------------------
-export PATH="`cscppc --print-path-to-wrap`:$PATH"
+export PATH="$(cscppc --print-path-to-wrap):$PATH"
 -------------------------------------------------
 
 
@@ -78,7 +78,7 @@ OPTIONS
 EXIT STATUS
 -----------
 cscppc propagates the exit status returned by the compiler (in case cscppc
-succeeds to run the compiler).  The exit status returned by cppcheck does not
+succeeds to run the compiler).  The exit status returned by Cppcheck does not
 affect the resulting exit status.
 
 
@@ -86,7 +86,7 @@ ENVIRONMENT VARIABLES
 ---------------------
 *DEBUG_CSCPPC*::
     If set to a non-empty string, cscppc outputs the list of parameters given
-    to cppcheck to the standard output.
+    to Cppcheck to the standard output.
 
 *CSCPPC_ADD_OPTS*::
     cscppc expects a colon-separated list of Cppcheck options that should be
@@ -97,7 +97,7 @@ ENVIRONMENT VARIABLES
 
 BUGS
 ----
-Please report bugs and feature requests at https://github.com/csutils/cscppc .
+Please report bugs and feature requests at https://github.com/csutils/cscppc.
 
 
 AUTHOR

--- a/doc/csgcca.adoc
+++ b/doc/csgcca.adoc
@@ -58,7 +58,7 @@ line:
 
 If csgcca is installed on system, the following command activates the wrapper:
 -------------------------------------------------
-export PATH="`csgcca --print-path-to-wrap`:$PATH"
+export PATH="$(csgcca --print-path-to-wrap):$PATH"
 -------------------------------------------------
 
 
@@ -97,7 +97,7 @@ ENVIRONMENT VARIABLES
 
 BUGS
 ----
-Please report bugs and feature requests at https://github.com/csutils/cscppc .
+Please report bugs and feature requests at https://github.com/csutils/cscppc.
 
 
 AUTHOR

--- a/doc/csmatch.adoc
+++ b/doc/csmatch.adoc
@@ -4,7 +4,7 @@ csmatch(1)
 
 NAME
 ----
-csmatch - a compiler wrapper that runs the smatch analyzer in background
+csmatch - a compiler wrapper that runs the Smatch analyzer in background
 
 
 SYNOPSIS
@@ -14,15 +14,15 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-csmatch is a compiler wrapper that runs smatch in background.  Create a
+csmatch is a compiler wrapper that runs Smatch in background.  Create a
 symbolic link to csmatch named as your compiler (gcc, g++, ...) and put it
 to your $PATH.
 
-The following parameters are given to smatch by default:
+The following parameters are given to Smatch by default:
 
     * -D_Float128=long double
 
-The following parameters are passed to smatch from compiler's command line:
+The following parameters are passed to Smatch from compiler's command line:
 
     * -D...
 
@@ -62,7 +62,7 @@ The following file extensions are recognized as C/C++ source files:
 
 If csmatch is installed on system, the following command activates the wrapper:
 -------------------------------------------------
-export PATH="`csmatch --print-path-to-wrap`:$PATH"
+export PATH="$(csmatch --print-path-to-wrap):$PATH"
 -------------------------------------------------
 
 
@@ -78,7 +78,7 @@ OPTIONS
 EXIT STATUS
 -----------
 csmatch propagates the exit status returned by the compiler (in case csmatch
-succeeds to run the compiler).  The exit status returned by smatch does not
+succeeds to run the compiler).  The exit status returned by Smatch does not
 affect the resulting exit status.
 
 
@@ -86,11 +86,11 @@ ENVIRONMENT VARIABLES
 ---------------------
 *DEBUG_CSMATCH*::
     If set to a non-empty string, csmatch outputs the list of parameters given
-    to smatch to the standard output.
+    to Smatch to the standard output.
 
 *CSMATCH_ADD_OPTS*::
-    csmatch expects a colon-separated list of smatch options that should be
-    appended to command line prior to invoking smatch.  The options are
+    csmatch expects a colon-separated list of Smatch options that should be
+    appended to command line prior to invoking Smatch.  The options are
     appended even if they already appear in the command line and they are
     always appended at the end of the command line.
 


### PR DESCRIPTION
* Use modern syntax for command substitution, e.g. `cmd` -> $(cmd).
* Make capitalization of tool names consistent.
* Remove some redundant spaces.