### PR TITLE
Modernize spec file

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -88,6 +88,10 @@ else
 fi
 
 cat > "$SPEC" << EOF
+# Disable in source builds on EPEL <9
+%undefine __cmake_in_source_build
+%undefine __cmake3_in_source_build
+
 Name:       $PKG
 Version:    $VER
 Release:    1%{?dist}
@@ -158,23 +162,19 @@ in background fully transparently.
 %autosetup
 
 %build
-mkdir cscppc_build
-cd cscppc_build
-%cmake3 .. -S.. -B.                           \\
+%cmake3                                       \\
     -DPATH_TO_CSCPPC=\"%{_libdir}/cscppc\"    \\
     -DPATH_TO_CSCLNG=\"%{_libdir}/csclng\"    \\
     -DPATH_TO_CSGCCA=\"%{_libdir}/csgcca\"    \\
     -DPATH_TO_CSMATCH=\"%{_libdir}/csmatch\"  \\
     -DSTATIC_LINKING=ON
-make %{?_smp_mflags} VERBOSE=yes
+%cmake3_build
 
 %check
-cd cscppc_build
-ctest3 %{?_smp_mflags} --output-on-failure
+%ctest3
 
 %install
-cd cscppc_build
-make install DESTDIR="\$RPM_BUILD_ROOT"
+%cmake3_install
 
 install -m0755 -d "\$RPM_BUILD_ROOT%{_libdir}"{,/cs{cppc,clng,gcca,match}}
 

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -97,7 +97,6 @@ Version:    $VER
 Release:    1%{?dist}
 Summary:    A compiler wrapper that runs cppcheck in background
 
-Group:      Development/Tools
 License:    GPLv3+
 URL:        https://github.com/csutils/%{name}
 Source0:    https://github.com/csutils/%{name}/releases/download/%{name}-%{version}/%{name}-%{version}.tar.xz

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -95,7 +95,7 @@ cat > "$SPEC" << EOF
 Name:       $PKG
 Version:    $VER
 Release:    1%{?dist}
-Summary:    A compiler wrapper that runs cppcheck in background
+Summary:    A compiler wrapper that runs Cppcheck in background
 
 License:    GPLv3+
 URL:        https://github.com/csutils/%{name}
@@ -128,7 +128,7 @@ Requires: cppcheck >= 1.85
 Conflicts: csdiff < 1.8.0
 
 %description
-This package contains the cscppc compiler wrapper that runs cppcheck in
+This package contains the cscppc compiler wrapper that runs Cppcheck in
 background fully transparently.
 
 %package -n csclng
@@ -148,11 +148,11 @@ This package contains the csgcca compiler wrapper that runs 'gcc -fanalyzer'
 in background fully transparently.
 
 %package -n csmatch
-Summary: A compiler wrapper that runs smatch in background
+Summary: A compiler wrapper that runs Smatch in background
 Requires: clang
 
 %description -n csmatch
-This package contains the csmatch compiler wrapper that runs the smatch analyzer
+This package contains the csmatch compiler wrapper that runs the Smatch analyzer
 in background fully transparently.
 
 %prep

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -142,6 +142,7 @@ in background fully transparently.
 
 %package -n csgcca
 Summary: A compiler wrapper that runs GCC analyzer in background
+Requires: gcc
 
 %description -n csgcca
 This package contains the csgcca compiler wrapper that runs GCC analyzer
@@ -149,7 +150,7 @@ in background fully transparently.
 
 %package -n csmatch
 Summary: A compiler wrapper that runs Smatch in background
-Requires: clang
+# Requires: smatch  (not in Fedora yet)
 
 %description -n csmatch
 This package contains the csmatch compiler wrapper that runs the Smatch analyzer

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -155,7 +155,7 @@ This package contains the csmatch compiler wrapper that runs the smatch analyzer
 in background fully transparently.
 
 %prep
-%setup -q
+%autosetup
 
 %build
 mkdir cscppc_build

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -176,20 +176,20 @@ in background fully transparently.
 %install
 %cmake3_install
 
-install -m0755 -d "\$RPM_BUILD_ROOT%{_libdir}"{,/cs{cppc,clng,gcca,match}}
+install -m0755 -d "%{buildroot}%{_libdir}"{,/cs{cppc,clng,gcca,match}}
 
 for i in cc gcc %{_arch}-redhat-linux-gcc
 do
-    ln -s ../../bin/cscppc "\$RPM_BUILD_ROOT%{_libdir}/cscppc/\$i"
-    ln -s ../../bin/csclng "\$RPM_BUILD_ROOT%{_libdir}/csclng/\$i"
-    ln -s ../../bin/csgcca "\$RPM_BUILD_ROOT%{_libdir}/csgcca/\$i"
-    ln -s ../../bin/csmatch "\$RPM_BUILD_ROOT%{_libdir}/csmatch/\$i"
+    ln -s ../../bin/cscppc  "%{buildroot}%{_libdir}/cscppc/\$i"
+    ln -s ../../bin/csclng  "%{buildroot}%{_libdir}/csclng/\$i"
+    ln -s ../../bin/csgcca  "%{buildroot}%{_libdir}/csgcca/\$i"
+    ln -s ../../bin/csmatch "%{buildroot}%{_libdir}/csmatch/\$i"
 done
 
 for i in c++ g++ %{_arch}-redhat-linux-c++ %{_arch}-redhat-linux-g++
 do
-    ln -s ../../bin/cscppc   "\$RPM_BUILD_ROOT%{_libdir}/cscppc/\$i"
-    ln -s ../../bin/csclng++ "\$RPM_BUILD_ROOT%{_libdir}/csclng/\$i"
+    ln -s ../../bin/cscppc   "%{buildroot}%{_libdir}/cscppc/\$i"
+    ln -s ../../bin/csclng++ "%{buildroot}%{_libdir}/csclng/\$i"
 done
 
 %files

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -141,10 +141,10 @@ This package contains the csclng compiler wrapper that runs the Clang analyzer
 in background fully transparently.
 
 %package -n csgcca
-Summary: A compiler wrapper that runs 'gcc -fanalyzer' in background
+Summary: A compiler wrapper that runs GCC analyzer in background
 
 %description -n csgcca
-This package contains the csgcca compiler wrapper that runs 'gcc -fanalyzer'
+This package contains the csgcca compiler wrapper that runs GCC analyzer
 in background fully transparently.
 
 %package -n csmatch

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -106,6 +106,12 @@ BuildRequires: asciidoc
 BuildRequires: cmake3
 BuildRequires: gcc
 
+# csmock copies the resulting cscppc binary into mock chroot, which may contain
+# an older (e.g. RHEL-7) version of glibc, and it would not dynamically link
+# against the old version of glibc if it was built against a newer one.
+# Therefore, we link glibc statically.
+BuildRequires: glibc-static
+
 # The test-suite runs automatically trough valgrind if valgrind is available
 # on the system.  By not installing valgrind into mock's chroot, we disable
 # this feature for production builds on architectures where valgrind is known
@@ -114,14 +120,6 @@ BuildRequires: gcc
 # valgrind manually to improve test coverage on any architecture.
 %ifarch %{ix86} x86_64
 BuildRequires: valgrind
-%endif
-
-# csmock copies the resulting cscppc binary into mock chroot, which may contain
-# an older (e.g. RHEL-5) version of glibc, and it would not dynamically link
-# against the old version of glibc if it was built against a newer one.
-# Therefor we link glibc statically.
-%if (0%{?fedora} >= 12 || 0%{?rhel} >= 6)
-BuildRequires: glibc-static
 %endif
 
 # the {cwe} field in --template option is supported since cppcheck-1.85


### PR DESCRIPTION
* use `%autosetup` instead of `%setup -q`
* use `%cmake3{,_build,_install}` and `%ctest3` macros
* use `%{buildroot}` instead of `$RPM_BUILD_ROOT`
* drop compatibility with RHEL 5
* drop obsolete `Group` tag
* make capitalization of tool names consistent
* make `csgcca`'s `%description` consistent with its manual page 