### PR TITLE
packaging: uncomment Requires for smatch

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -150,7 +150,7 @@ in background fully transparently.
 
 %package -n csmatch
 Summary: A compiler wrapper that runs Smatch in background
-# Requires: smatch  (not in Fedora yet)
+Recommends: smatch
 
 %description -n csmatch
 This package contains the csmatch compiler wrapper that runs the Smatch analyzer


### PR DESCRIPTION
The smatch package is now available in Fedora.

Related: https://src.fedoraproject.org/rpms/smatch