### PR TITLE
packaging: make the spec file compatible with EPEL-7 again

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -150,7 +150,9 @@ in background fully transparently.
 
 %package -n csmatch
 Summary: A compiler wrapper that runs Smatch in background
+%if 0%{?rhel} != 7
 Recommends: smatch
+%endif
 
 %description -n csmatch
 This package contains the csmatch compiler wrapper that runs the Smatch analyzer


### PR DESCRIPTION
rpmbuild in EPEL-7 does not support weak dependencies:
```
[...]
Start: buildsrpm
Start: rpmbuild -bs
error: line 63: Unknown tag: Recommends: smatch
Building target platforms: x86_64
Building for target x86_64
Finish: rpmbuild -bs
Finish: buildsrpm
ERROR: Exception(/var/lib/copr-rpmbuild/workspace/workdir-y7rr3tva/cscppc/cscppc.spec) Config(centos+epel-7-x86_64) 1 minutes 19 seconds
```

Fixes: commit 77112754b1bd846045a0dea8268c0197249de986