### PR TITLE
cswrap-core: skip known wrappers while invoking an analyzer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,8 +88,9 @@ macro(add_cs_executable name sources)
     string(REGEX REPLACE "\\+\\+$" "" name_upper ${name_upper})
 
     if(PATH_TO_${name_upper})
-        target_compile_definitions(${name}
-            PRIVATE -DPATH_TO_${name_upper}=${PATH_TO_${name_upper}})
+        set(def -DPATH_TO_${name_upper}=${PATH_TO_${name_upper}})
+        target_compile_definitions(cswrap PRIVATE ${def})
+        target_compile_definitions(${name} PRIVATE ${def})
     endif()
 
     install(TARGETS ${name} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
We want to hook `gcc -fanalyzer` on `clang` if `clang` is used as the system compiler.  However, it does not make sense to hook GCC Analyzer on `clang --analyze`, which is invoked by `csclng` while wrapping `gcc` as the system compiler.

Apart from wasting resources by running multiple processes of GCC Analyzer in parallel, this was causing unnecessary noise in `scan.log` as GCC Analyzer complained about unsupported flags, which were injected by `csclng` for `clang --analyze` only:
```
gcc: error: unrecognized command-line option ‘-fno-caret-diagnostics’
gcc: error: unrecognized command-line option ‘-fno-caret-diagnostics’
gcc: error: unrecognized command-line option ‘-fno-caret-diagnostics’
```

Reported-by: Lukáš Zaoral
Fixes: commit 983b89554df60cee70b5861dff39d82b4672bbbf
Related: https://github.com/csutils/cscppc/pull/43
Closes: https://github.com/csutils/cscppc/pull/44