### PR TITLE
cmake: raise minimum required version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2014 - 2022 Red Hat, Inc.
+# Copyright (C) 2014 - 2025 Red Hat, Inc.
 #
 # This file is part of cscppc.
 #
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with cscppc.  If not, see <http://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5)
 project(cscppc C)
 enable_testing()
 


### PR DESCRIPTION
... to fix the following CMake 4.0 error:
```
CMake Error at CMakeLists.txt:18 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```