### PR TITLE
make-srpm.sh: update cmake macros and deps for cmake4

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,7 +3,9 @@ name: Coverity
 
 on:
   push:
-    branches: [main]
+    branches:
+      - coverity
+      # - main
 
 jobs:
   coverity:

--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -90,7 +90,6 @@ fi
 cat > "$SPEC" << EOF
 # Disable in source builds on EPEL <9
 %undefine __cmake_in_source_build
-%undefine __cmake3_in_source_build
 
 Name:       $PKG
 Version:    $VER
@@ -102,7 +101,7 @@ URL:        https://github.com/csutils/%{name}
 Source0:    https://github.com/csutils/%{name}/releases/download/%{name}-%{version}/%{name}-%{version}.tar.xz
 
 BuildRequires: asciidoc
-BuildRequires: cmake3
+BuildRequires: cmake
 BuildRequires: gcc
 
 # csmock copies the resulting cscppc binary into mock chroot, which may contain
@@ -165,19 +164,19 @@ in background fully transparently.
 %autosetup
 
 %build
-%cmake3                                       \\
+%cmake                                        \\
     -DPATH_TO_CSCPPC=\"%{_libdir}/cscppc\"    \\
     -DPATH_TO_CSCLNG=\"%{_libdir}/csclng\"    \\
     -DPATH_TO_CSGCCA=\"%{_libdir}/csgcca\"    \\
     -DPATH_TO_CSMATCH=\"%{_libdir}/csmatch\"  \\
     -DSTATIC_LINKING=ON
-%cmake3_build
+%cmake_build
 
 %check
-%ctest3
+%ctest
 
 %install
-%cmake3_install
+%cmake_install
 
 install -m0755 -d "%{buildroot}%{_libdir}"{,/cs{cppc,clng,gcca,match}}
 


### PR DESCRIPTION
## Summary
- Update `make-srpm.sh` to use `%cmake` macros instead of `%cmake3` (and corresponding `%cmake_build`, `%ctest`, `%cmake_install`), and change `BuildRequires: cmake3` to `cmake`, following the [Fedora CMake 4.0 change](https://fedoraproject.org/wiki/Changes/CMake4.0)
- Remove the now-unnecessary `%undefine __cmake3_in_source_build`
- Temporarily disable Coverity CI on the `main` branch since the Coverity Scan service has been down

## Test plan
- [ ] Verify the SRPM builds successfully with the updated cmake macros
- [ ] Confirm CI passes on the branch (excluding Coverity)